### PR TITLE
🐛 chore: remove linha duplicada do markdown no requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ matplotlib==3.10.3
 xhtml2pdf==0.2.17
 markdown==3.8
 reportlab==4.4.1
-markdown = 3.8
+


### PR DESCRIPTION
# Descrição  

Remoção da linha duplicada markdown==3.8 no arquivo requirements.txt.
Essa alteração corrige um problema de redundância que pode causar confusão durante a instalação das dependências. Não há impacto direto na funcionalidade da aplicação. Nenhuma dependência adicional é necessária.

Corrige # (#169 )

## Tipo de Mudança  

📌 **Prioridade:**  🟢 Baixa  

Por favor, marque as opções relevantes:  

- [ ] 🐞 **Correção de bug** (mudança que não quebra o sistema e resolve um problema)  
- [ ] ✨ **Nova funcionalidade** (mudança que não quebra o sistema e adiciona uma nova funcionalidade)  
- [ ] ⚠️ **Mudança que quebra o sistema** (correção ou funcionalidade que pode fazer com que a funcionalidade existente não funcione como esperado)  
- [x] 📚 **Atualização de documentação**  

## Checklist  

- [x] Meu código segue as diretrizes de estilo deste projeto  
- [x] Eu revisei meu próprio código  
- [ ] Comentei meu código, especialmente em áreas de difícil compreensão  
- [ ] Fiz mudanças correspondentes na documentação  
- [x] Minhas mudanças não geram novos avisos  

## Erro
```
Run python -m pip install --upgrade pip # Atualiza o pip
Requirement already satisfied: pip in /opt/hostedtoolcache/Python/3.13.5/x64/lib/python3.13/site-packages (25.1.1)
ERROR: Invalid requirement: 'markdown = 3.8': Expected end or semicolon (after name and no valid version specifier)
    markdown = 3.8
             ^ (from line 12 of requirements.txt)
Hint: = is not a valid operator. Did you mean == ?
Error: Process completed with exit code 1.
```
